### PR TITLE
Add full TLS support/allow loading of MSVC compiled Rust PEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ If you want to hardcode custom arguments modify `const exeArgs` to your needs an
 
 `nim c -d:args NimRunPE.nim` - this was contributed by [@glynx](https://github.com/glynx), thanks! :sunglasses:
 
+If you want full Thread Local Storage (TLS) callback support, **allowing execution of Rust PEs** etc, compile with:
+
+`nim c -d:full_tls NimRunPE.nim`
+
+Credit to [BlackBone](https://github.com/DarthTon/Blackbone) & [lander's blog](https://landaire.net/reflective-pe-loader-for-xbox/)/[solstice-loader](https://github.com/exploits-forsale/solstice/tree/main/crates/solstice_loader)
+for the implementation of the `full_tls` option.
+
 ## More Information
 
 The technique itself it pretty old, but I didn't find a Nim implementation yet. So this has changed now. :)


### PR DESCRIPTION
Adds a new compile option, `full_tls`, that enables loading PEs that rely on full TLS callback support.

`nim c -d:full_tls NimRunPE.nim`

Credit to [BlackBone](https://github.com/DarthTon/Blackbone) & [lander's blog](https://landaire.net/reflective-pe-loader-for-xbox/)/[solstice-loader](https://github.com/exploits-forsale/solstice/tree/main/crates/solstice_loader) for the implementation of the `full_tls` option.

Tries to find some private NTDLL functions to get the PEB correctly updated to add the new PE's TLS section. This causes new threads etc to be correctly initialized by TLS callbacks - main example being Rust PEs that use the standard library's `fn main()` implementation and are compiled with MSVC.

Should also support more "complex" Rust PEs that use multithreading and/or `async`/tokio.